### PR TITLE
Use pre-defined types and asarray()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ venv.bak/
 publish_old.py
 playground.py
 tests/debug.py
+
+# vim
+*.swp

--- a/multivar_horner/helper_fcts.py
+++ b/multivar_horner/helper_fcts.py
@@ -2,9 +2,11 @@
 
 import numpy as np
 
+from .global_settings import UINT_DTYPE, FLOAT_DTYPE
+
 
 def rectify_coefficients(coefficients):
-    rectified_coefficients = np.atleast_1d(np.array(coefficients, dtype=np.float64)).reshape(-1, 1)
+    rectified_coefficients = np.atleast_1d(np.asarray(coefficients, dtype=FLOAT_DTYPE)).reshape(-1, 1)
     return rectified_coefficients
 
 
@@ -18,11 +20,10 @@ def rectify(coefficients, exponents):
     """
     rectified_coefficients = rectify_coefficients(coefficients)
 
-    rectified_exponents = np.atleast_2d(np.array(exponents, dtype=np.int))
+    rectified_exponents = np.atleast_2d(np.asarray(exponents, dtype=UINT_DTYPE))
     # exponents must not be negative!
     # ATTENTION: when converting to unsigned integer, negative integers become large!
     assert not np.any(rectified_exponents < 0)
-    rectified_exponents = rectified_exponents.astype(np.uint32)
 
     # ignore the entries with 0.0 coefficients
     if np.any(rectified_coefficients == 0.0):
@@ -35,7 +36,7 @@ def rectify(coefficients, exponents):
 
 def validate_coefficients(coefficients) -> None:
 
-    assert type(coefficients) is np.ndarray, 'coefficients must be given as numpy ndarray'
+    assert isinstance(coefficients, np.ndarray), 'coefficients must be given as numpy ndarray'
     assert len(coefficients.shape) == 2 and coefficients.shape[1] == 1, \
         'coefficients must be given as a [n, 1] ndarray'
 

--- a/multivar_horner/multivar_horner.py
+++ b/multivar_horner/multivar_horner.py
@@ -106,7 +106,7 @@ class AbstractPolynomial(ABC):
 
         self.num_monomials: int = self.exponents.shape[0]
         self.dim: int = self.exponents.shape[1]
-        self.unused_variables = np.where(~np.any(self.exponents, axis=1))[0]
+        self.unused_variables = np.where(~np.any(self.exponents.astype(BOOL_DTYPE), axis=1))[0]
         self.total_degree: int = np.max(np.sum(self.exponents, axis=0))
         self.euclidean_degree: float = np.max(np.linalg.norm(self.exponents, ord=2, axis=0))
         self.maximal_degree: int = np.max(self.exponents)
@@ -297,7 +297,7 @@ class MultivarPolynomial(AbstractPolynomial):
         """
 
         if validate_input:
-            x = np.array(x)
+            x = np.asarray(x)
             assert len(x.shape) == 1
             assert x.shape[0] == self.dim
 
@@ -503,7 +503,7 @@ class HornerMultivarPolynomial(AbstractPolynomial):
         """
 
         if validate_input:
-            x = np.array(x, dtype=np.float)
+            x = np.asarray(x, dtype=FLOAT_DTYPE)
             assert len(x.shape) == 1
             assert x.shape[0] == self.dim
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,7 +5,7 @@ import sys
 import numpy as np
 
 from multivar_horner import HornerMultivarPolynomial, MultivarPolynomial
-from multivar_horner.global_settings import UINT_DTYPE
+from multivar_horner.global_settings import UINT_DTYPE, FLOAT_DTYPE
 from tests.test_settings import MAX_COEFF_MAGNITUDE, MAX_NUMERICAL_ERROR, NR_COEFF_CHANGES, NR_TEST_POLYNOMIALS
 
 
@@ -98,7 +98,7 @@ def all_possible_exponents(dim, deg):
     #     all_possible[i] = cntr2exp_vect(i)
 
     for i, exponents in enumerate(itertools.product(range(deg + 1), repeat=dim)):
-        all_possible[i] = exponents
+        all_possible[i] = np.asarray(exponents)
 
     # there must not be duplicate exponent vectors
     assert all_possible.shape == np.unique(all_possible, axis=0).shape
@@ -139,7 +139,7 @@ def evaluate_numerical_error(dim, max_degree):
     # basic idea: evaluating a polynomial at x = all 1 should give the sum of coefficients
     # -> any deviation is the numerical error
     results = []
-    x = np.ones(dim, dtype=np.float)
+    x = np.ones(dim, dtype=FLOAT_DTYPE)
     max_error = 0.0
     ctr_total = 0
     ctr_total_max = NR_TEST_POLYNOMIALS * NR_COEFF_CHANGES

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -19,7 +19,7 @@ from itertools import product
 import numpy as np
 import pytest
 
-from multivar_horner.global_settings import UINT_DTYPE
+from multivar_horner.global_settings import UINT_DTYPE, FLOAT_DTYPE
 from multivar_horner.multivar_horner import HornerMultivarPolynomial, MultivarPolynomial
 # settings for numerical stability tests
 from tests.test_helpers import evaluate_numerical_error, naive_eval_reference, proto_test_case, vectorize
@@ -39,8 +39,8 @@ class MainTest(unittest.TestCase):
         :return:
         """
         print('\nTESTING COSNTRUCTION API...')
-        coefficients = np.array([[5.0], [1.0], [2.0], [3.0]], dtype=np.float64)
-        exponents = np.array([[0, 0, 0], [3, 1, 0], [2, 0, 1], [1, 1, 1]], dtype=np.uint32)
+        coefficients = np.array([[5.0], [1.0], [2.0], [3.0]], dtype=FLOAT_DTYPE)
+        exponents = np.array([[0, 0, 0], [3, 1, 0], [2, 0, 1], [1, 1, 1]], dtype=UINT_DTYPE)
 
         polynomial1 = MultivarPolynomial(coefficients, exponents, compute_representation=False)
         polynomial2 = MultivarPolynomial(coefficients, exponents, compute_representation=True)


### PR DESCRIPTION
 Streamline array conversions, checks and dtypes

* Use `asarray()` instead of `array()` to avoid unnecessary copies
* Use pre-defined dtypes instead of `np.<dtype>` directly

Tests pass. Those fixes don't change any behavior. We're testing a pytorch version of this code and the fixes in this PR address issues that don't pop up when using numpy due to silent casting, whereas torch is more strict in that respect. 